### PR TITLE
Fix position property in widget.css

### DIFF
--- a/widget.css
+++ b/widget.css
@@ -2,7 +2,7 @@
     width: 250px;
     padding: 0 15px;
     background-color: rgb(226, 225, 225);
-    position: absolute;
+    position: fixed;
     bottom: 10px;
     right: 10px;
     padding: 8px 8px;


### PR DESCRIPTION
While scrolling, widget moves along with the page.
The issue here is that position property should be not 'absolute', but 'fixed', so it will have fixed coordinates on the page, so it will stay on the same place, even on scroll.